### PR TITLE
Support using channel ids in chan for Slack

### DIFF
--- a/platforms/slack/sendmesg.js
+++ b/platforms/slack/sendmesg.js
@@ -31,7 +31,7 @@ async function sendmesg(client, commandCache, message) {
     if (user && priv) {
         channelId = user;
     } else {
-        const channel = channels.find((c) => c.name === chan);
+        const channel = channels.find((c) => c.name === chan || c.id === chan);
         channelId = channel.id;
     }
 


### PR DESCRIPTION
It's much easier to use channel IDs for mpims on Slack when we're
using the HTTP API.